### PR TITLE
fix: 修复nb命令无法安装插件的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _✨ 让我看看！！赛博露阴癖，将你的代码展示到群聊 ✨_
 在 NoneBot2 项目的根目录下打开命令行，输入以下指令即可安装：
 
 ```bash
-nb plugin install nonebot-plugin-exhibitionism
+nb plugin install nonebot_plugin_exhibitionism
 ```
 
 ### 使用包管理器安装


### PR DESCRIPTION
在使用nb命令时，插件名应该使用`_`来分割，如果使用`-`分割的话会抛出`RuntimeError: No or multiple packages found`。